### PR TITLE
Update FB.java

### DIFF
--- a/xgetter/src/main/java/com/htetznaing/lowcostvideo/Sites/FB.java
+++ b/xgetter/src/main/java/com/htetznaing/lowcostvideo/Sites/FB.java
@@ -20,23 +20,14 @@ public class FB {
     public static void fetch(String url, final LowCostVideo.OnTaskCompleted onTaskCompleted){
         AndroidNetworking.post("https://fdown.net/download.php")
                 .addBodyParameter("URLz", "https://www.facebook.com/video.php?v="+ url)
-                .addHeaders("User-agent", agent)
                 .build()
                 .getAsString(new StringRequestListener() {
                     @Override
                     public void onResponse(String response) {
                         ArrayList<XModel> xModels = new ArrayList<>();
-                        String sd = getFbLink(response, false);
-                        if (sd!=null){
-                            putModel(sd,"SD",xModels);
-                        }
-                        String hd = getFbLink(response, true);
-                        if (hd!=null) {
-                            putModel(hd, "HD", xModels);
-                        }
-                        if (xModels.isEmpty()){
-                            onTaskCompleted.onError();
-                        }else onTaskCompleted.onTaskCompleted(xModels,true);
+                        putModel(getFbLink(response, false), "SD", xModels);
+                        putModel(getFbLink(response, true), "HD", xModels);
+                        onTaskCompleted.onTaskCompleted(xModels, true);
                     }
 
                     @Override


### PR DESCRIPTION
removes header (not needed) fixes Facebook link for downloads. MainActivity sample edit text should now be able to get a Facebook video ID.